### PR TITLE
feat: restrict GIAB benchmark to target regions

### DIFF
--- a/benchmarks/giab-na12878-exome/download.sh
+++ b/benchmarks/giab-na12878-exome/download.sh
@@ -3,4 +3,4 @@ IFS=$'\n\t'
 
 source=`dirname "$0"`
 
-snakemake download --snakefile $source/workflow/Snakefile --directory $prefix --cores 1 --use-conda --show-failed-logs
+snakemake download --snakefile $source/workflow/Snakefile --directory $prefix --cores 1 --use-conda --show-failed-logs --all-temp

--- a/benchmarks/giab-na12878-exome/download.sh
+++ b/benchmarks/giab-na12878-exome/download.sh
@@ -3,4 +3,4 @@ IFS=$'\n\t'
 
 source=`dirname "$0"`
 
-snakemake download --snakefile $source/workflow/Snakefile --directory $prefix --cores 1 --use-conda --show-failed-logs --all-temp
+snakemake download --cores 2 --snakefile $source/workflow/Snakefile --directory $prefix --use-conda --show-failed-logs --all-temp

--- a/benchmarks/giab-na12878-exome/eval.sh
+++ b/benchmarks/giab-na12878-exome/eval.sh
@@ -3,4 +3,4 @@ IFS=$'\n\t'
 
 source=`dirname "$0"`
 
-snakemake eval --snakefile $source/workflow/Snakefile --directory $prefix --config results=`realpath $results` --cores 1 --use-conda
+snakemake eval --snakefile $source/workflow/Snakefile --directory $prefix --config results=`realpath $results` --cores 1 --use-conda --all-temp

--- a/benchmarks/giab-na12878-exome/workflow/Snakefile
+++ b/benchmarks/giab-na12878-exome/workflow/Snakefile
@@ -5,9 +5,11 @@ include: "rules/download.smk"
 rule download:
     input:
         reads,
-        expand("test-regions.cov-{cov}.bed", cov=["low", "callable"]),
-        "truth.vcf",
-        "reference.fasta.fai",
+        expand("benchmark/test-regions.cov-{cov}.bed", cov=["low", "callable"]),
+        "reference/reference.fasta",
+        "reference/reference.fasta.fai",
+        "benchmark/truth.vcf",
+        "benchmark/target-regions.bed",
 
 
 if "results" in config:

--- a/benchmarks/giab-na12878-exome/workflow/envs/tools.yaml
+++ b/benchmarks/giab-na12878-exome/workflow/envs/tools.yaml
@@ -6,3 +6,4 @@ dependencies:
   - samtools =1.14
   - curl =7
   - bedtools =2.30
+  - ucsc-liftover =377

--- a/benchmarks/giab-na12878-exome/workflow/rules/common.smk
+++ b/benchmarks/giab-na12878-exome/workflow/rules/common.smk
@@ -1,4 +1,4 @@
-chromosome = "15"
+chromosome = "1"
 repl_chr = "s/chr//"
 reads = expand("reads.{read}.fq", read=[1, 2])
 bwa_index = multiext("reference", ".amb", ".ann", ".bwt", ".pac", ".sa")

--- a/benchmarks/giab-na12878-exome/workflow/rules/download.smk
+++ b/benchmarks/giab-na12878-exome/workflow/rules/download.smk
@@ -71,7 +71,7 @@ rule get_target_bed:
         " liftOver /dev/stdin {input.liftover} {output} /dev/null) 2> {log}"
 
 
-rule fix_target_bed:
+rule postprocess_target_bed:
     input:
         "benchmark/target-regions.raw.bed"
     output:
@@ -80,10 +80,11 @@ rule fix_target_bed:
         "logs/fix-target-bed.log"
     params:
         repl_chr=repl_chr,
+        chromosome=chromosome,
     conda:
         "../envs/tools.yaml"
     shell:
-        "sed {params.repl_chr} {input} > {output} 2> {log}"
+        "grep chr{params.chromosome} {input} | sed {params.repl_chr} > {output} 2> {log}"
 
 
 rule get_chromosome:

--- a/benchmarks/giab-na12878-exome/workflow/rules/download.smk
+++ b/benchmarks/giab-na12878-exome/workflow/rules/download.smk
@@ -49,7 +49,7 @@ rule get_liftover_track:
     output:
         "benchmark/liftover.chain.gz",
     log:
-        "logs/get-liftover-track.log"
+        "logs/get-liftover-track.log",
     conda:
         "../envs/tools.yaml"
     shell:
@@ -62,7 +62,7 @@ rule get_target_bed:
     output:
         pipe("benchmark/target-regions.raw.bed"),
     log:
-        "logs/get-target-bed.log"
+        "logs/get-target-bed.log",
     conda:
         "../envs/tools.yaml"
     shell:
@@ -73,11 +73,11 @@ rule get_target_bed:
 
 rule postprocess_target_bed:
     input:
-        "benchmark/target-regions.raw.bed"
+        "benchmark/target-regions.raw.bed",
     output:
-        "benchmark/target-regions.bed"
+        "benchmark/target-regions.bed",
     log:
-        "logs/fix-target-bed.log"
+        "logs/fix-target-bed.log",
     params:
         repl_chr=repl_chr,
         chromosome=chromosome,

--- a/benchmarks/giab-na12878-exome/workflow/rules/download.smk
+++ b/benchmarks/giab-na12878-exome/workflow/rules/download.smk
@@ -45,6 +45,47 @@ rule get_confidence_bed:
         "sed {params.repl_chr} > {output} 2> {log}"
 
 
+rule get_liftover_track:
+    output:
+        "benchmark/liftover.chain.gz",
+    log:
+        "logs/get-liftover-track.log"
+    conda:
+        "../envs/tools.yaml"
+    shell:
+        "curl --insecure -L http://hgdownload.soe.ucsc.edu/goldenPath/hg19/liftOver/hg19ToHg38.over.chain.gz > {output} 2> {log}"
+
+
+rule get_target_bed:
+    input:
+        liftover="benchmark/liftover.chain.gz",
+    output:
+        pipe("benchmark/target-regions.raw.bed"),
+    log:
+        "logs/get-target-bed.log"
+    conda:
+        "../envs/tools.yaml"
+    shell:
+        "(curl --insecure -L"
+        " ftp://ftp-trace.ncbi.nih.gov/ReferenceSamples/giab/data/NA12878/Nebraska_NA12878_HG001_TruSeq_Exome/TruSeq_exome_targeted_regions.hg19.bed |"
+        " liftOver /dev/stdin {input.liftover} {output} /dev/null) 2> {log}"
+
+
+rule fix_target_bed:
+    input:
+        "benchmark/target-regions.raw.bed"
+    output:
+        "benchmark/target-regions.bed"
+    log:
+        "logs/fix-target-bed.log"
+    params:
+        repl_chr=repl_chr,
+    conda:
+        "../envs/tools.yaml"
+    shell:
+        "sed {params.repl_chr} {input} > {output} 2> {log}"
+
+
 rule get_chromosome:
     output:
         "reference/reference.fasta",
@@ -148,6 +189,7 @@ rule mosdepth:
 rule stratify_regions:
     input:
         confidence="benchmark/confidence-regions.bed",
+        target="benchmark/target-regions.bed",
         coverage="coverage/coverage.quantized.bed.gz",
     output:
         "benchmark/test-regions.cov-{cov}.bed",
@@ -158,7 +200,8 @@ rule stratify_regions:
     conda:
         "../envs/tools.yaml"
     shell:
-        "bedtools intersect "
-        "-a {input.confidence} "
-        "-b <(zcat {input.coverage} | grep '{params.cov_label}') "
-        "> {output} 2> {log}"
+        "(bedtools intersect"
+        " -a {input.confidence}"
+        " -b <(zcat {input.coverage} | grep '{params.cov_label}') |"
+        " bedtools intersect -a /dev/stdin -b {input.target}"
+        ") > {output} 2> {log}"


### PR DESCRIPTION
Rationale: in non-targeted regions, we have an enrichment of false mappers, which generates artificially hard to handle regions for the caller, in particular since such enrichments violate caller assumptions about frequencies.